### PR TITLE
Atualização da API + ajuste enum

### DIFF
--- a/Braspag.podspec
+++ b/Braspag.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Braspag Api'
-  s.version          = '0.1.0'
+  s.version          = '0.2.0'
   s.summary          = 'SDK de integração com a API da Braspag.'
 
   s.homepage         = 'https://github.com/Braspag/BraspagApiiOSSdk'

--- a/Braspag/Classes/request/BPBraspag.m
+++ b/Braspag/Classes/request/BPBraspag.m
@@ -18,7 +18,7 @@
 
 - (void)createSale:(BPSale *)sale success:(BPRequestSuccessBlock)success failure:(BPRequestFailureBlock)failure; {
     NSDictionary *saleParams = [BPJSONAdapter JSONDictionaryFromModel:sale error:nil];
-    [[self apiManager] POST:@"/1/sales"
+    [[self apiManager] POST:@"/v2/sales"
                   parameters:saleParams
                    progress:nil
                     success:[self successBlock:success]
@@ -26,7 +26,7 @@
 }
 
 - (void)querySale:(NSString *)paymentId success:(BPRequestSuccessBlock)success failure:(BPRequestFailureBlock)failure; {
-    [[self apiQueryManager] GET:[NSString stringWithFormat:@"/1/sales/%@", paymentId]
+    [[self apiQueryManager] GET:[NSString stringWithFormat:@"/v2/sales/%@", paymentId]
                      parameters:nil
                        progress:nil
                         success:[self successBlock:success]
@@ -34,14 +34,14 @@
 }
 
 - (void)cancelSale:(NSString *)paymentId withAmount:(int)amount success:(BPRequestSuccessBlock)success failure:(BPRequestFailureBlock)failure {
-    [[self apiManager] PUT:[NSString stringWithFormat:@"/1/sales/%@/void?amount=%i", paymentId, amount]
+    [[self apiManager] PUT:[NSString stringWithFormat:@"/v2/sales/%@/void?amount=%i", paymentId, amount]
                 parameters:nil
                    success:[self successBlock:success]
                    failure:[self failureBlock:failure]];
 }
 
 - (void)cancelSale:(NSString *)paymentId success:(BPRequestSuccessBlock)success failure:(BPRequestFailureBlock)failure; {
-    [[self apiManager] PUT:[NSString stringWithFormat:@"/1/sales/%@/void", paymentId]
+    [[self apiManager] PUT:[NSString stringWithFormat:@"/v2/sales/%@/void", paymentId]
                 parameters:nil
                    success:[self successBlock:success]
                    failure:[self failureBlock:failure]];
@@ -52,7 +52,7 @@
 andServiceTaxAmount:(int)serviceTaxAmount
             success:(BPRequestSuccessBlock)success
             failure:(BPRequestFailureBlock)failure {
-    [[self apiManager] PUT:[NSString stringWithFormat:@"/1/sales/%@/capture?amount=%i&serviceTaxAmount=%i", paymentId, amount, serviceTaxAmount]
+    [[self apiManager] PUT:[NSString stringWithFormat:@"/v2/sales/%@/capture?amount=%i&serviceTaxAmount=%i", paymentId, amount, serviceTaxAmount]
                 parameters:nil
                    success:[self successBlock:success]
                    failure:[self failureBlock:failure]];
@@ -62,14 +62,14 @@ andServiceTaxAmount:(int)serviceTaxAmount
          withAmount:(int)amount
             success:(BPRequestSuccessBlock)success
             failure:(BPRequestFailureBlock)failure {
-    [[self apiManager] PUT:[NSString stringWithFormat:@"/1/sales/%@/capture?amount=%i", paymentId, amount]
+    [[self apiManager] PUT:[NSString stringWithFormat:@"/v2/sales/%@/capture?amount=%i", paymentId, amount]
                 parameters:nil
                    success:[self successBlock:success]
                    failure:[self failureBlock:failure]];
 }
 
 - (void)captureSale:(NSString *)paymentId success:(BPRequestSuccessBlock)success failure:(BPRequestFailureBlock)failure {
-    [[self apiManager] PUT:[NSString stringWithFormat:@"/1/sales/%@/capture", paymentId]
+    [[self apiManager] PUT:[NSString stringWithFormat:@"/v2/sales/%@/capture", paymentId]
                 parameters:nil
                    success:[self successBlock:success]
                    failure:[self failureBlock:failure]];

--- a/Braspag/Classes/request/objects/BPPayment.h
+++ b/Braspag/Classes/request/objects/BPPayment.h
@@ -69,4 +69,7 @@ typedef enum {
 @property NSString *digitableLine;
 @property NSString *address;
 
++ (BPPaymentType)convertStringToBPPaymentType:(NSString *)value;
++ (BPPaymentProvider)convertStringToBPPaymentProvider:(NSString *)value;
+
 @end

--- a/Braspag/Classes/request/objects/BPPayment.m
+++ b/Braspag/Classes/request/objects/BPPayment.m
@@ -85,6 +85,45 @@
     return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:typeDict];
 }
 
+
+/**
+ Converte uma String para enum (BPPaymentType).
+ 
+ @param value String relacionada ao enum
+ @return String convertida em enum
+ */
++ (BPPaymentType)convertStringToBPPaymentType:(NSString *)value {
+    
+    if ([value isEqualToString:@"CreditCard"]) {
+        return CreditCard;
+    } else if ([value isEqualToString:@"DebitCard"]) {
+        return DebitCard;
+    } else if ([value isEqualToString:@"ElectronicTransfer"]) {
+        return ElectronicTransfer;
+    } else {
+        return Boleto;
+    }
+    
+}
+
+/**
+ Converte uma String para enum (BPPaymentProvider).
+ 
+ @param value String relacionada ao enum
+ @return String convertida em enum
+ */
++ (BPPaymentProvider)convertStringToBPPaymentProvider:(NSString *)value {
+    
+    if ([value isEqualToString:@"Bradesco"]) {
+        return Bradesco;
+    } else if ([value isEqualToString:@"BancoDoBrasil"]) {
+        return BancoDoBrasil;
+    } else {
+        return Simulado;
+    }
+    
+}
+
 + (NSValueTransformer *)currencyJSONTransformer {
     NSDictionary *currencyDict = @{
                                    @"BRL": @(BRL),


### PR DESCRIPTION
Estou utilizando o SDK em swift e a linguagem entende que os enums BPPaymentProvider e BPPaymentType são do tipo Int, portanto não consigo instancia-los a partir do método rawValue. 

Para causar menos impacto simplesmente criei um método que inicia este Enum a partir de uma String. O correto depois seria converter esses enums para Int mesmo, acredito que não será um refactor muito grande.

Aproveitando essa alteração também atualizei o SDK para utilizar a versão v2 da API.

Qualquer dúvida ou sugestão, entre em contado. 
